### PR TITLE
Literate CoffeeScript support

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -10,7 +10,7 @@ module.exports =
   'CoffeeScript (Literate)':
     render: (text, cb) ->
       coffeescript = require 'coffee-script'
-      result = coffeescript.compile text
+      result = coffeescript.compile text, literate: true
       cb null, result
     lang: -> 'js'
   #'TypeScript':


### PR DESCRIPTION
As of version 0.1.0, this package treats .litcoffee files as .coffee files, which almost always fails with parser errors. This PR will compile Literate CoffeeScript to JavaScript, which will also remove all Markdown content.

Once [support for Markdown](https://github.com/Glavin001/atom-preview/issues/7) is in place, we may want to have an option to choose whether to preview Literate CoffeeScript as JavaScript or HTML.
