### PR TITLE
Use same font as editor

### DIFF
--- a/lib/preview-view.coffee
+++ b/lib/preview-view.coffee
@@ -35,6 +35,10 @@ class PreviewView extends ScrollView
     atom.config.observe 'editor.fontSize', () =>
       @changeHandler()
 
+    # Update on font-family change
+    atom.config.observe 'editor.fontFamily', () =>
+      @changeHandler()
+
     # Setup debounced renderer
     atom.config.observe 'preview.refreshDebouncePeriod', \
     (wait) =>
@@ -171,6 +175,10 @@ class PreviewView extends ScrollView
       fontSize = atom.config.get('editor.fontSize')
       if fontSize?
         codeBlock.css('font-size', fontSize)
+      # Set font-family from Editor to the Preview
+      fontFamily = atom.config.get('editor.fontFamily')
+      if fontFamily?
+        codeBlock.css('font-family', fontFamily)
     # Start preview processing
     text = @editor.getText()
     try


### PR DESCRIPTION
The preview should use the same font family as in the editor. Will probably also solve issue #25
