### PR TITLE
Preview shouldn't be focused

### DIFF
--- a/lib/preview-view.coffee
+++ b/lib/preview-view.coffee
@@ -103,6 +103,9 @@ class PreviewView extends ReactEditorView
   getUri: ->
     "preview://editor"
 
+  focus: ->
+    false
+
   changeHandler: () =>
     @debouncedRenderPreview()
 


### PR DESCRIPTION
Looked through the Atom core some and from my testing this seems to fix issue #48 for me. Haven't done any large testing though so might cause other issues that I haven't noticed.
