### PR TITLE
Preserve line-breaks in compiler error messages

### DIFF
--- a/lib/preview-message-view.coffee
+++ b/lib/preview-message-view.coffee
@@ -3,5 +3,5 @@ module.exports = class PreviewMessageView extends View
   @content: ->
     @div =>
       @div
-        class: 'overlay from-top'
+        class: 'overlay preview-overlay-full from-top'
         outlet: 'message'

--- a/lib/preview-view.coffee
+++ b/lib/preview-view.coffee
@@ -127,7 +127,14 @@ class PreviewView extends HTMLElement
 
   showError: (result) ->
     # console.log('showError', result)
-    failureMessage = result?.message
+    failureMessage = if result and result.message 
+      '<div class="text-error preview-text-error">' + result.message.replace(/\n/g, '<br/>') + '</div>' 
+    else 
+      ""
+    stackDump = if result and result.stack 
+      '<div class="text-warning preview-text-warning">' + result.stack.replace(/\n/g, '<br/>') + '</div>' 
+    else 
+      ""
     @showMessage()
     @messageView.message.html $$$ ->
       @div
@@ -137,15 +144,10 @@ class PreviewView extends HTMLElement
           @span
             class: 'loading loading-spinner-large inline-block'
           @div
-            class: 'text-highlight',
+            class: 'text-highlight preview-text-highlight',
             'Previewing Failed\u2026'
-            =>
-              @div
-                class: 'text-error'
-                failureMessage if failureMessage?
-          @div
-            class: 'text-warning'
-            result?.stack
+          @raw failureMessage if failureMessage?
+          @raw stackDump if stackDump?
 
   showLoading: ->
     @showMessage()
@@ -157,7 +159,7 @@ class PreviewView extends HTMLElement
           @span
             class: 'loading loading-spinner-large inline-block'
           @div
-            class: 'text-highlight',
+            class: 'text-highlight preview-text-highlight',
             'Loading Preview\u2026'
 
   showMessage: ->

--- a/styles/main.less
+++ b/styles/main.less
@@ -33,4 +33,16 @@
     right: 0;
     left: 0;
   }
+
+  .preview-text-highlight { text-align: left; }
+  .preview-text-error { text-align: left; }
+  .preview-text-warning { text-align: left; }
+
+  .preview-overlay-full {
+    width: 100%;
+    height: 100%;
+    left: 0px;
+    margin-left: 0px;
+    padding: 10%;
+  }
 }


### PR DESCRIPTION
Pull request for issue #100
https://github.com/Glavin001/atom-preview/issues/100

Now error messages are much easier to read overall without the center alignment, esp. those that attempt to format a caret beneath the offending character in the line e.g. Coffescript.

Also:  per our discussion in the issue above, I added just some minimal styles necessary to achieve the formatting (which was to left align the text, plus expanding the message overlay to fill the entire preview tab).

The rest of the formatting still comes from the styles in their theme.  

I did confirm I could change the theme and and the error messages still looked fine.

@Glavin001 ready for review
 