### PR TITLE
Update CoffeeScript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-preset-stage-3": "^6.5.0",
     "clear-require": "^1.0.1",
     "coffee-react": "^5.0.0",
-    "coffee-script": "^1.7.1",
+    "coffee-script": "^1.10.0",
     "dogeon": "^1.0.0",
     "dogescript": "^2.3.0",
     "ember-script": "0.0.14",


### PR DESCRIPTION
Fixes #120 (error with `yield` keyword, since it was not added until CS 1.9.0)